### PR TITLE
Can now 'make rpm' to build an RPM for IIQTools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - "2.6"
   - "2.7"
 
+before_install:
+  - sudo apt-get install -y libpq-dev postgresql
+
 install:
   - pip install -r requirements-dev.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
 
 before_install:
+  - sudo apt-get purge -y libpq-dev
   - sudo apt-get install -y postgresql-9.3 postgresql-server-dev-9.3
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 
 before_install:
-  - sudo apt-get install -y libpq-dev
+  - sudo apt-get install -y postgresql-9.3 postgresql-server-dev-9.3
 
 install:
   - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 
 before_install:
-  - sudo apt-get install -y libpq-dev postgresql
+  - sudo apt-get install -y libpq-dev
 
 install:
   - pip install -r requirements-dev.txt

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,1 @@
-Copyright 2017 Dell EMC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Copyright 2017 Dell EMC, Licensed under the Apache License, Version 2.0

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ test: install
 
 lint: install
 	pylint iiqtools
+
+rpm: clean
+	python setup.py bdist_rpm --requires isilon-insightiq --binary-only


### PR DESCRIPTION
This will make installing IIQTools easier for instances of InsightIQ that do not have access to the public Internet/PyPi