### PR TITLE
replaced use of double under bar with triple, fixes #14

### DIFF
--- a/docs/source/patching.rst
+++ b/docs/source/patching.rst
@@ -67,10 +67,10 @@ to enable us to uninstall the patch. Within that directory, you'll see some rath
 long file names::
 
   \originals
-    insightiq__controllers__security.py
+    insightiq___controllers___security.py
 
-The double-underbars ``__`` are used to replace the forward slash normally associated
-with a file system path. A double-underbar is used instead of a single-underbar
+The triple-underbars ``___`` are used to replace the forward slash normally associated
+with a file system path. A triple-underbar is used instead of a single-underbar
 because it's common for a Python source file to contain a single-underbar.
 
 What's in a patch

--- a/iiqtools/iiq_patch.py
+++ b/iiqtools/iiq_patch.py
@@ -331,9 +331,9 @@ def convert_patch_name(name, to='source'):
     :type to: Enum -> 'source', 'backup'
     """
     if to == 'source':
-        return name.replace('__', '/')
+        return name.replace('___', '/')
     elif to == 'backup':
-        return name.replace('/', '__')
+        return name.replace('/', '___')
     else:
         raise ValueError('param "to" must be either "source" or "backup", supplied: %s' % to)
 

--- a/iiqtools_tests/test_iiq_patch.py
+++ b/iiqtools_tests/test_iiq_patch.py
@@ -270,7 +270,7 @@ class TestValidators(unittest.TestCase):
     def test_expected_backups_ok(self):
         """iiq_patch.expected_backups returns True if the source file copies found meet the patches expectations"""
         fake_logger = MagicMock()
-        found_backups = ['path__to__some_file.py']
+        found_backups = ['path___to___some_file.py']
         expected_backups = ['path/to/some_file.py']
 
         result = iiq_patch.expected_backups(found_backups, expected_backups, fake_logger)
@@ -329,8 +329,24 @@ class TestUtils(unittest.TestCase):
 
     def test_convert_patch_name_to_source(self):
         """"iiq_patch.convert_patch_name correctly converts a backup file name to the source path"""
-        name = 'some__backup_copy.py'
+        name = 'some___backup_copy.py'
         expected = 'some/backup_copy.py'
+        result = iiq_patch.convert_patch_name(name, to='source')
+
+        self.assertEqual(expected, result)
+
+    def test_convert_duner_files_to_backup(self):
+        """iiq_patch.convert_patch_name handles double-under files, like __init__.py when converting to backup name"""
+        name = 'some/__init__.py'
+        expected = 'some_____init__.py'
+        result = iiq_patch.convert_patch_name(name, to='backup')
+
+        self.assertEqual(expected, result)
+
+    def test_convert_duner_files_to_source(self):
+        """iiq_patch.convert_patch_name handles double-under files, like __init__.py when converting to source name"""
+        name = 'some_____init__.py'
+        expected = 'some/__init__.py'
         result = iiq_patch.convert_patch_name(name, to='source')
 
         self.assertEqual(expected, result)
@@ -338,7 +354,7 @@ class TestUtils(unittest.TestCase):
     def test_convert_patch_name_to_backup(self):
         """"iiq_patch.convert_patch_name correctly converts source file path to a backup file name"""
         name = 'some/backup_copy.py'
-        expected = 'some__backup_copy.py'
+        expected = 'some___backup_copy.py'
         result = iiq_patch.convert_patch_name(name, to='backup')
 
         self.assertEqual(expected, result)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ ldap3==1.3.1
 nose>=1.3.7
 pylint
 configobj==5.0.6
+isort==4.2.0


### PR DESCRIPTION
This fix allows patching of files like `__init__.py`. 
Before this fix, we'd mistakingly rename something like `insightiq/__init__.py` to `insightiq_____init__.py` when saving a backup copy. 
This would cause chaos when attempting to uninstall the patch because `insightiq____init__.py` would be converted to `some//init/.py`

I figured, "let's just add another underbar!" :P 