### PR TITLE
Update docs, fixes #28 and #29

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -8,9 +8,16 @@ Install and Upgrade
 This section provides directions to install or upgrade the IIQTools package
 for your instance of InsightIQ.
 
-.. note::
+Installing the RPM
+------------------
 
-  The ``--upgrade`` flag is automatically ignored if you're performing an initial install
+This is by far the easiest way to install IIQTools.
+
+1. Download the newest RPM `here <https://github.com/willnx/iiqtools/releases>`_
+#. Copy the RPM file onto the machine running InsightIQ
+#. Install with this command, replacing ``</path/to/rpm>`` with the literal file path::
+
+   $ sudo yum install --disablerepo=* <path/to/rpm>
 
 Installing Python pip
 ---------------------
@@ -20,6 +27,11 @@ of InsightIQ doesn't have pip installed, there are some pretty simple directions
 at:
 
 https://pip.pypa.io/en/stable/installing/
+
+
+.. note::
+
+  The ``--upgrade`` flag is automatically ignored if you're performing an initial install
 
 
 With Internet connection

--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -220,6 +220,11 @@ To create the ``iiq_backup`` user account, run the following command::
 
   [administrator@localhost ~]$ sudo useradd iiq_backup && sudo passwd iiq_backup
 
+Once that user is created, you'll have to give them access to the key file::
+
+  [administrator@localhost ~]$ sudo chmod 440 /etc/isilon/secret_key
+  [administrator@localhost ~]$ sudo chown :iiq_backup /etc/isilon/secret_key
+
 
 Usage Examples
 --------------


### PR DESCRIPTION
Docs now inform users of RPM install, and includes steps to give `iiq_backup` read access to the key file (only `root`, `administrator`, and now `iiq_backup` can read it)